### PR TITLE
Allow to sent on condition multiple times

### DIFF
--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -108,11 +108,9 @@ function preSend(action, store, options) {
     if (!onlyState) add(data, options, state);
     let shouldSend = false;
     if (
-      options.sendOnCondition &&
-      !options.sentOnCondition && options.sendOnCondition(state, action)
+      options.sendOnCondition && options.sendOnCondition(state, action)
     ) {
       shouldSend = true;
-      options.sentOnCondition = true;
     }
     if (
       shouldSend ||


### PR DESCRIPTION
- Allow `sendOnCondition` to run multiples times.

This will allow us to have a better way of controlling when to send the data.

For example in the function `sendOnCondition` I can write some code that ANY time an action ends with `_FAILURE ` is dispatched I want to send that to Sentry, currently to do that I need to explicitly set all the actions in the `sendOn` attribute (as an array of all possibilities) 

What do you think about this @zalmoxisus?
Is there any reason why do you intentionally want this `sendOnCondition` to run only the first time the condition is met??